### PR TITLE
Undo/Redo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "antd": "^5.11.5",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-icons": "^5.0.1",
                 "react-router-dom": "^6.20.1",
                 "react-scripts": "^5.0.1",
                 "rete": "^2.0.2",
@@ -15955,6 +15956,14 @@
             "version": "6.0.11",
             "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
             "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+        },
+        "node_modules/react-icons": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+            "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+            "peerDependencies": {
+                "react": "*"
+            }
         },
         "node_modules/react-is": {
             "version": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "rete-connection-plugin": "^2.0.0",
                 "rete-context-menu-plugin": "^2.0.0",
                 "rete-engine": "^2.0.0",
+                "rete-history-plugin": "^2.0.0",
                 "rete-react-plugin": "^2.0.4",
                 "rete-render-utils": "^2.0.1",
                 "styled-components": "^5.3.11",
@@ -16460,6 +16461,18 @@
             },
             "peerDependencies": {
                 "rete": "^2.0.1"
+            }
+        },
+        "node_modules/rete-history-plugin": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/rete-history-plugin/-/rete-history-plugin-2.0.0.tgz",
+            "integrity": "sha512-F2n5iacIthf0v83LRmrp4VPx1Q1QnRZ3Wu/pFzeecaNqstps07+D8O32p1yFUqj4Bsp/t6WtBxSYl1VcDuw56A==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "peerDependencies": {
+                "rete": "^2.0.1",
+                "rete-area-plugin": "^2.0.0"
             }
         },
         "node_modules/rete-react-plugin": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "rete-connection-plugin": "^2.0.0",
         "rete-context-menu-plugin": "^2.0.0",
         "rete-engine": "^2.0.0",
+        "rete-history-plugin": "^2.0.0",
         "rete-react-plugin": "^2.0.4",
         "rete-render-utils": "^2.0.1",
         "styled-components": "^5.3.11",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "antd": "^5.11.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^5.0.1",
         "react-router-dom": "^6.20.1",
         "react-scripts": "^5.0.1",
         "rete": "^2.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,10 +88,10 @@ function App() {
                     GitHub
                 </a>
                 <div style={{ flexGrow: 1 }} />
-                <Button style={{ border: 'none' }}>
+                <Button style={{ border: 'none' }} onClick={() => editor?.undo()}>
                     <FaUndo className={`${"icon-button"}`} />
                 </Button>
-                <Button style={{border: 'none'}}>
+                <Button style={{border: 'none'}} onClick={() => editor?.redo()}>
                     <FaRedo className={`${"icon-button"}`} />
                 </Button>
                 <Button onClick={() => editor?.layout(true)}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import './rete.css'
 import { createEditor } from './rete'
 import { Layout, Button, Flex, Select, Divider } from 'antd'
 import { Link } from 'react-router-dom'
+import { FaRedo, FaUndo } from "react-icons/fa";
 
 let selectedExample = 'Default'
 
@@ -87,6 +88,12 @@ function App() {
                     GitHub
                 </a>
                 <div style={{ flexGrow: 1 }} />
+                <Button style={{ border: 'none' }}>
+                    <FaUndo className={`${"icon-button"}`} />
+                </Button>
+                <Button style={{border: 'none'}}>
+                    <FaRedo className={`${"icon-button"}`} />
+                </Button>
                 <Button onClick={() => editor?.layout(true)}>
                     Auto-arrange nodes
                 </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,11 @@ code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
         monospace;
 }
+
+.icon-button{
+    color: white;
+}
+  
+.icon-button:hover {
+    color: #000055;
+}

--- a/src/rete/default.tsx
+++ b/src/rete/default.tsx
@@ -236,7 +236,7 @@ export async function createEditor(container: HTMLElement) {
 
     HistoryExtensions.keyboard(history);
     
-    history.addPreset(HistoryPresets.classic.setup());
+    history.addPreset(HistoryPresets.classic.setup({ timing: 0.01 }));
 
 
     function process() {
@@ -459,6 +459,10 @@ export async function createEditor(container: HTMLElement) {
     AreaExtensions.zoomAt(area, editor.getNodes())
 
     await editor.removeConnection(c.id)
+    
+    //Clear history so tracking actions (for undo/redo)
+    //start with user interactions not the loaded example.
+    history.clear()
 
     process()
 
@@ -477,6 +481,10 @@ export async function createEditor(container: HTMLElement) {
     }
     async function loadExample(exampleName: string) {
         await loadEditor(examples[exampleName].json)
+        
+        //Clear history so tracking actions (for undo/redo)
+        //start with user interactions not the loaded example.
+        history.clear()
     }
     function GetExampleDescription(exampleName: string) {
         return examples[exampleName].concepts

--- a/src/rete/default.tsx
+++ b/src/rete/default.tsx
@@ -28,6 +28,12 @@ import {
 } from 'rete-context-menu-plugin'
 
 import {
+    HistoryExtensions,
+    HistoryPlugin,
+    Presets as HistoryPresets
+} from 'rete-history-plugin'
+
+import {
     DropdownControl,
     CustomDropdownControl,
 } from './controls/DropdownControl'

--- a/src/rete/default.tsx
+++ b/src/rete/default.tsx
@@ -232,6 +232,12 @@ export async function createEditor(container: HTMLElement) {
     const area = new AreaPlugin<Schemes, AreaExtra>(container)
     const editor = new NodeEditor<Schemes>()
     const engine = new DataflowEngine<Schemes>()
+    const history = new HistoryPlugin<Schemes>();
+
+    HistoryExtensions.keyboard(history);
+    
+    history.addPreset(HistoryPresets.classic.setup());
+
 
     function process() {
         if (processQueued) {
@@ -352,6 +358,7 @@ export async function createEditor(container: HTMLElement) {
     area.use(contextMenu)
     area.use(connection)
     area.use(arrange)
+    area.use(history);
 
     area.area.setZoomHandler(
         new SmoothZoom(0.4, 200, 'cubicBezier(.45,.91,.49,.98)', area)

--- a/src/rete/default.tsx
+++ b/src/rete/default.tsx
@@ -536,6 +536,13 @@ export async function createEditor(container: HTMLElement) {
         initAudio()
         process()
     }
+    function undo(){
+        history.undo()
+    }
+    function redo(){
+        history.redo()
+    }
+
 
     return {
         layout: async (animate: boolean) => {
@@ -555,6 +562,8 @@ export async function createEditor(container: HTMLElement) {
         },
         loadExample,
         toggleAudio,
+        undo,
+        redo,
         GetExampleDescription,
     }
 }


### PR DESCRIPTION
## Added Undo/Redo functionality via icon buttons and keyboard shortcuts (Ctrl+Z and Ctrl+Y)

### **Changes**
- Used Rete's HistoryExtensionPlugin for functionality

- Imported [React Icons](https://react-icons.github.io/react-icons/). To resolve the dependency on local instances, please run `npm install react-icons --save`

- CSS styling added for redo/undo icon buttons so it changes color on hover (see src/index.css

- Fixed bug where all nodes of loaded examples were completely removed on undo. It makes more sense to start tracking the history of the user's interactions and leave the generated example content as a base.

### **Video Demo**
https://github.com/WebAudio-Node-Editor/webaudio-node-editor/assets/37406675/c6197ae9-ed17-4844-b289-795b4a951631

Contributors: Arthi Krishna (ak4606) & Hanna Martin (hem2162)