### PR TITLE
Allow empty number input field, but set value internally to zero

### DIFF
--- a/src/rete/controls/LabeledInputControl.tsx
+++ b/src/rete/controls/LabeledInputControl.tsx
@@ -37,6 +37,27 @@ export function CustomLabeledInputControl(props: {
         setValue(props.data.value)
     }, [props.data.value])
 
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const val = (
+            props.data.type === 'number'
+                ? (String(e.target.value) === '' ? '' : +e.target.value)
+                : e.target.value
+        ) as (typeof props.data)['value']
+
+        // If input is empty, keep field empty, but set value internally as zero
+        setValue(val)
+        // props.data.setValue(String(val) === '' ? 0 : val); // this line SHOULD give us required behavior, but doesn't
+        props.data.setValue(val); // this line unexpectedly gives us required behavior
+    }
+
+    const handleBlur = () => {
+        // If input field is out of focus and empty, set value to 0
+        if (String(value) === '') {
+            setValue(0);
+            props.data.setValue(0);
+        }
+    };
+
     return (
         <div>
             <div style={{ padding: '5px 6px' }}>{props.data.label}</div>
@@ -45,16 +66,8 @@ export function CustomLabeledInputControl(props: {
                 type={props.data.type}
                 ref={ref}
                 readOnly={props.data.readonly}
-                onChange={(e) => {
-                    const val = (
-                        props.data.type === 'number'
-                            ? +e.target.value
-                            : e.target.value
-                    ) as (typeof props.data)['value']
-
-                    setValue(val)
-                    props.data.setValue(val)
-                }}
+                onChange={handleChange}
+                onBlur={handleBlur}
                 step={props.data.increment}
                 styles={props.styles}
             />


### PR DESCRIPTION
Fix #21 

Although the description in #21 suggests setting the internal value of the input control to 0 (aka using the logic in line 49), doing so results in unwanted behavior. Specifically, the field value can only be deleted if it is a 0. If it is any other number, a 0 will be automatically inserted. This means that mashing the delete key will indeed empty the field, but not before inserting a 0. See video linked as an example.

https://github.com/WebAudio-Node-Editor/webaudio-node-editor/assets/59037606/0bb3febe-73c2-4fac-9eca-ebb02bc50425

However, if we don't set the internal value to 0 and just let it be an empty string (aka using the logic in line 50), we get our desired behavior.  My guess is that the function `props.data.setValue(val)` converts an empty string to a 0 internally automatically, but I'm unsure how to verify this with logs, as the logs shown in the video below show only empty strings. Overall, this solution seems hacky to me, and might lead to unexpected behavior elsewhere.

https://github.com/WebAudio-Node-Editor/webaudio-node-editor/assets/59037606/89399fee-cc95-4ca8-9ac7-cb2337a3a25a

Suggestions would be appreciated.
